### PR TITLE
Let cmd/bbcode have stdin be piped in.

### DIFF
--- a/cmd/bbcode/main.go
+++ b/cmd/bbcode/main.go
@@ -3,14 +3,27 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/frustra/bbcode"
+	"io/ioutil"
 	"os"
+
+	"github.com/frustra/bbcode"
 )
 
 func main() {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		panic(err)
+	}
 	compiler := bbcode.NewCompiler(true, true)
-	scanner := bufio.NewScanner(os.Stdin)
-	for scanner.Scan() {
-		fmt.Println(compiler.Compile(scanner.Text()))
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		//stdin is from a pipe. Compile it all at once.
+		b, _ := ioutil.ReadAll(os.Stdin)
+		fmt.Println(compiler.Compile(string(b)))
+	} else {
+		//stdin isn't from a pipe; compile it line-by-line.
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			fmt.Println(compiler.Compile(scanner.Text()))
+		}
 	}
 }


### PR DESCRIPTION
If data was piped into stdin from a file or other command, the reader would compile each individual line separately. This meant if I tried to open a tag like `[quote]`, the compiler would close it at the end of the line, even if there should have been more content.

This PR fixes that by checking if stdin is being piped in, and if it is, it attempts to read it all till EOF, and compiles it all at once.

Note that I don't know if this works in windows.